### PR TITLE
allow for specify custom api base & markdown linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 # PyOpenAI
 
-![](https://img.shields.io/github/languages/top/jaredmontoya/pyopenai?style=flat)
-![](https://img.shields.io/github/languages/code-size/jaredmontoya/pyopenai?style=flat)
+![chip](https://img.shields.io/github/languages/top/jaredmontoya/pyopenai?style=flat)
+![chip](https://img.shields.io/github/languages/code-size/jaredmontoya/pyopenai?style=flat)
 
 An attempt to reimplement python OpenAI API bindings in nim
 
-## Project Status:
+## Project Status
+
 - streams not implemented
 - async not implemented
 - not fully tested so if you encounter errors open an issue
 
 If you need features that are not implemented yet, try [openaiclient](https://nimble.directory/pkg/openaiclient) but at the time of writing this, it's nimble package is broken and cannot be used as it has no sources in it, so you have to download and import sources manually.
 
-### What is implemented:
+### What is implemented
+
 - [Models](https://platform.openai.com/docs/api-reference/models)
 - [Completions](https://platform.openai.com/docs/api-reference/completions)
 - [ChatCompletions](https://platform.openai.com/docs/api-reference/chat)
@@ -24,25 +26,27 @@ If you need features that are not implemented yet, try [openaiclient](https://ni
 - [Fine-Tunes](https://platform.openai.com/docs/api-reference/fine-tunes)
 - [Moderations](https://platform.openai.com/docs/api-reference/moderations)
 
-# Installation
+## Installation
+
 To install pyopenai, you can simply run
-```
+
+```bash
 nimble install pyopenai
 ```
+
 - Uninstall with `nimble uninstall pyopenai`.
 - [Nimble repo page](https://nimble.directory/pkg/pyopenai)
 
-# Requisites
+## Requisites
 
 - [Nim](https://nim-lang.org)
 
-# Example
+## Example
+
 ```nim
 import pyopenai, json, os
 
-var openai = OpenAiClient(
-    apiKey: getEnv("OPENAI_API_KEY")
-)
+var openai = newOpenAiClient(getEnv("OPENAI_API_KEY"))
 
 let response = openai.createCompletion(
     model = "text-davinci-003",

--- a/pyopenai.nimble
+++ b/pyopenai.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.0"
+version       = "0.1.1"
 author        = "jaredmontoya"
 description   = "An attempt to reimplement python OpenAI API bindings in nim"
 license       = "MIT"

--- a/src/pyopenai.nim
+++ b/src/pyopenai.nim
@@ -1,6 +1,8 @@
 import pyopenai/types
 export types
 
+import pyopenai/utils
+export utils
 
 import pyopenai/api/models
 export models

--- a/src/pyopenai/api/audio.nim
+++ b/src/pyopenai/api/audio.nim
@@ -1,6 +1,5 @@
 import httpclient, json
 
-import ../consts
 import ../types
 import ../utils
 
@@ -30,7 +29,7 @@ proc createAudioTranscription*(self: OpenAiClient,
         data.add({"language": language})
 
     let resp = buildHttpClient(self, "multipart/form-data").post(
-            OpenAiBaseUrl&"/audio/transcriptions", multipart = data)
+            self.apiBase&"/audio/transcriptions", multipart = data)
     case resp.status
         of $Http200:
             return resp.body.parseJson()["text"].str
@@ -65,7 +64,7 @@ proc createAudioTranslation*(self: OpenAiClient,
         data.add({"temperature": $temperature})
 
     let resp = buildHttpClient(self, "multipart/form-data").post(
-            OpenAiBaseUrl&"/audio/translations", multipart = data)
+            self.apiBase&"/audio/translations", multipart = data)
     case resp.status
         of $Http200:
             return resp.body.parseJson()["text"].str

--- a/src/pyopenai/api/completions.nim
+++ b/src/pyopenai/api/completions.nim
@@ -1,6 +1,5 @@
 import httpclient, json
 
-import ../consts
 import ../types
 import ../utils
 
@@ -71,7 +70,7 @@ proc createCompletion*(self: OpenAiClient,
         body.add("user", %user)
 
     let resp = buildHttpClient(self, "application/json").post(
-            OpenAiBaseUrl&"/completions", body = $body)
+            self.apiBase&"/completions", body = $body)
     case resp.status
         of $Http200:
             return resp.body.parseJson()
@@ -133,7 +132,7 @@ proc createChatCompletion*(self: OpenAiClient,
         body.add("user", %user)
 
     let resp = buildHttpClient(self, "application/json").post(
-            OpenAiBaseUrl&"/chat/completions", body = $body)
+            self.apiBase&"/chat/completions", body = $body)
     case resp.status
         of $Http200:
             return resp.body.parseJson()

--- a/src/pyopenai/api/edits.nim
+++ b/src/pyopenai/api/edits.nim
@@ -1,6 +1,5 @@
 import httpclient, json
 
-import ../consts
 import ../types
 import ../utils
 
@@ -33,7 +32,7 @@ proc createEdit*(self: OpenAiClient,
         body.add("top_p", %topP)
 
     let resp = buildHttpClient(self, "application/json").post(
-            OpenAiBaseUrl&"/edits", body = $body)
+            self.apiBase&"/edits", body = $body)
     case resp.status
         of $Http200:
             return resp.body.parseJson()

--- a/src/pyopenai/api/embeddings.nim
+++ b/src/pyopenai/api/embeddings.nim
@@ -1,6 +1,5 @@
 import httpclient, json
 
-import ../consts
 import ../types
 import ../utils
 
@@ -21,7 +20,7 @@ proc createEmbedding*(self: OpenAiClient,
         body.add("user", %user)
 
     let resp = buildHttpClient(self, "application/json").post(
-            OpenAiBaseUrl&"/embeddings", body = $body)
+            self.apiBase&"/embeddings", body = $body)
     case resp.status
         of $Http200:
             return resp.body.parseJson()

--- a/src/pyopenai/api/files.nim
+++ b/src/pyopenai/api/files.nim
@@ -1,13 +1,12 @@
 import httpclient, json
 
-import ../consts
 import ../types
 import ../utils
 
 
 proc getFileList*(self: OpenAiClient): JsonNode =
     let resp = buildHttpClient(self).get(
-            OpenAiBaseUrl&"/files")
+            self.apiBase&"/files")
     case resp.status
         of $Http200:
             return resp.body.parseJson()
@@ -30,7 +29,7 @@ proc uploadFile*(self: OpenAiClient,
     data.addFiles({"file": file})
 
     let resp = buildHttpClient(self).post(
-            OpenAiBaseUrl&"/files", multipart = data)
+            self.apiBase&"/files", multipart = data)
     case resp.status
         of $Http200:
             return resp.body.parseJson()
@@ -48,7 +47,7 @@ proc deleteFile*(self: OpenAiClient, fileId: string): JsonNode =
     # deletes the file on openai
 
     let resp = buildHttpClient(self).delete(
-            OpenAiBaseUrl&"/files/"&fileId)
+            self.apiBase&"/files/"&fileId)
     case resp.status
         of $Http200:
             return resp.body.parseJson()
@@ -64,7 +63,7 @@ proc getFile*(self: OpenAiClient, fileId: string): JsonNode =
     # gets information about specified file
 
     let resp = buildHttpClient(self).get(
-            OpenAiBaseUrl&"/files/"&fileId)
+            self.apiBase&"/files/"&fileId)
     case resp.status
         of $Http200:
             return resp.body.parseJson()
@@ -82,6 +81,6 @@ proc downloadFile*(self: OpenAiClient, fileId: string): void =
     let filename: string = self.getFile(fileId)["filename"].str
 
     try:
-        buildHttpClient(self).downloadFile(OpenAiBaseUrl&"/files/"&fileId&"/content", filename)
+        buildHttpClient(self).downloadFile(self.apiBase&"/files/"&fileId&"/content", filename)
     except HttpRequestError:
         raise newException(HttpRequestError, "To help mitigate abuse, downloading of fine-tune training files is disabled for free accounts.")

--- a/src/pyopenai/api/finetunes.nim
+++ b/src/pyopenai/api/finetunes.nim
@@ -1,6 +1,5 @@
 import httpclient, json
 
-import ../consts
 import ../types
 import ../utils
 
@@ -8,7 +7,7 @@ import ../utils
 proc getFineTunes*(self: OpenAiClient): JsonNode =
     ## gets a list of ``FineTune``s
 
-    let resp = buildHttpClient(self).get(OpenAiBaseUrl&"/fine-tunes")
+    let resp = buildHttpClient(self).get(self.apiBase&"/fine-tunes")
     case resp.status
         of $Http200:
             return resp.body.parseJson()
@@ -21,7 +20,7 @@ proc getFineTunes*(self: OpenAiClient): JsonNode =
 proc getFineTune*(self: OpenAiClient, fineTuneId: string): FineTune =
     ## gets a ``FineTune``
 
-    let resp = buildHttpClient(self).get(OpenAiBaseUrl&"/fine-tunes/"&fineTuneId)
+    let resp = buildHttpClient(self).get(self.apiBase&"/fine-tunes/"&fineTuneId)
     case resp.status
         of $Http200:
             return resp.body.parseJson()
@@ -36,7 +35,7 @@ proc getFineTune*(self: OpenAiClient, fineTuneId: string): FineTune =
 proc getFineTuneEvents*(self: OpenAiClient, fineTuneId: string): JsonNode =
     ## gets ``FineTune``'s events
 
-    let resp = buildHttpClient(self).get(OpenAiBaseUrl&"/fine-tunes/"&fineTuneId&"/events")
+    let resp = buildHttpClient(self).get(self.apiBase&"/fine-tunes/"&fineTuneId&"/events")
     case resp.status
         of $Http200:
             return resp.body.parseJson()
@@ -103,7 +102,7 @@ proc createFineTune*(self: OpenAiClient,
         body.add("suffix", %suffix)
 
     let resp = buildHttpClient(self, "application/json").post(
-            OpenAiBaseUrl&"/fine-tunes", body = $body)
+            self.apiBase&"/fine-tunes", body = $body)
     case resp.status
         of $Http200:
             return resp.body.parseJson()
@@ -120,7 +119,7 @@ proc createFineTune*(self: OpenAiClient,
 proc cancelFineTune*(self: OpenAiClient, fineTuneId: string): FineTune =
     ## cancels a ``FineTune``
 
-    let resp = buildHttpClient(self).post(OpenAiBaseUrl&"/fine-tunes/"&fineTuneId&"/cancel")
+    let resp = buildHttpClient(self).post(self.apiBase&"/fine-tunes/"&fineTuneId&"/cancel")
     case resp.status
         of $Http200:
             return resp.body.parseJson()

--- a/src/pyopenai/api/images.nim
+++ b/src/pyopenai/api/images.nim
@@ -1,6 +1,5 @@
 import httpclient, json
 
-import ../consts
 import ../types
 import ../utils
 
@@ -31,7 +30,7 @@ proc createImage*(self: OpenAiClient,
         body.add("user", %user)
 
     let resp = buildHttpClient(self, "application/json").post(
-            OpenAiBaseUrl&"/images/generations", body = $body)
+            self.apiBase&"/images/generations", body = $body)
     case resp.status
         of $Http200:
             return resp.body.parseJson()
@@ -78,7 +77,7 @@ proc createImageEdit*(self: OpenAiClient,
         data.add({"user": user})
 
     let resp = buildHttpClient(self, "multipart/form-data").post(
-            OpenAiBaseUrl&"/images/edits", multipart = data)
+            self.apiBase&"/images/edits", multipart = data)
     case resp.status
         of $Http200:
             return resp.body.parseJson()
@@ -118,7 +117,7 @@ proc createImageVariation*(self: OpenAiClient,
         data.add({"user": user})
 
     let resp = buildHttpClient(self, "multipart/form-data").post(
-            OpenAiBaseUrl&"/images/variations", multipart = data)
+            self.apiBase&"/images/variations", multipart = data)
     case resp.status
         of $Http200:
             return resp.body.parseJson()

--- a/src/pyopenai/api/models.nim
+++ b/src/pyopenai/api/models.nim
@@ -1,6 +1,5 @@
 import httpclient, json
 
-import ../consts
 import ../types
 import ../utils
 
@@ -9,7 +8,7 @@ proc getModelList*(self: OpenAiClient): JsonNode =
     ## gets list of available models
 
     let resp = buildHttpClient(self).get(
-            OpenAiBaseUrl&"/models")
+            self.apiBase&"/models")
     case resp.status
         of $Http200:
             return resp.body.parseJson()
@@ -23,7 +22,7 @@ proc getModel*(self: OpenAiClient, model: string): JsonNode =
     ## gets model details
 
     let resp = buildHttpClient(self).get(
-            OpenAiBaseUrl&"/models/"&model)
+            self.apiBase&"/models/"&model)
     case resp.status
         of $Http200:
             return resp.body.parseJson()
@@ -37,7 +36,7 @@ proc getModel*(self: OpenAiClient, model: string): JsonNode =
 proc deleteModel*(self: OpenAiClient, model: string): JsonNode =
     # deletes the model on openai
 
-    let resp = buildHttpClient(self).delete(OpenAiBaseUrl&"/models/"&model)
+    let resp = buildHttpClient(self).delete(self.apiBase&"/models/"&model)
     case resp.status
         of $Http200:
             return resp.body.parseJson()

--- a/src/pyopenai/api/moderations.nim
+++ b/src/pyopenai/api/moderations.nim
@@ -1,6 +1,5 @@
 import httpclient, json
 
-import ../consts
 import ../types
 import ../utils
 
@@ -19,7 +18,7 @@ proc createModeration*(self: OpenAiClient,
         body.add("model", %model)
 
     let resp = buildHttpClient(self, "application/json").post(
-            OpenAiBaseUrl&"/moderations", body = $body)
+            self.apiBase&"/moderations", body = $body)
     case resp.status
         of $Http200:
             return resp.body.parseJson()

--- a/src/pyopenai/types.nim
+++ b/src/pyopenai/types.nim
@@ -1,8 +1,8 @@
 import json
 
-
 type
     OpenAiClient* = object
+        apiBase*: string
         apiKey*: string
         organization*: string
         userAgent*: string

--- a/src/pyopenai/utils.nim
+++ b/src/pyopenai/utils.nim
@@ -1,6 +1,13 @@
 import httpclient
 
+import consts
 import types
+
+proc newOpenAiClient*(): OpenAiClient =
+    OpenAiClient(apiBase: OpenAiBaseUrl)
+
+proc newOpenAiClient*(apiKey: string): OpenAiClient =
+    OpenAiClient(apiBase: OpenAiBaseUrl, apiKey: apiKey)
 
 proc buildHttpClient*(client: OpenAiClient, contentType = ""): HttpClient =
 

--- a/tests/t_api.nim
+++ b/tests/t_api.nim
@@ -1,9 +1,19 @@
-# import unittest
+import unittest
+import os
+import json
+import strutils
 
-# import pyopenai
+import pyopenai
 
-# suite "Generations Tests":
-#     test "Completions":
-#         check 5 == 5
-#     test "Images":
-#         check 5 == 5
+suite "Generations Tests":
+    test "Completions":
+        var openai = newOpenAiClient(getEnv("OPENAI_API_KEY"))
+
+        let response = openai.createCompletion(
+            model = "text-davinci-003",
+            prompt = "What's the capital of Poland? answer with one word.",
+            temperature = 0.6,
+            maxTokens = 50
+        )
+
+        check response["choices"][0]["text"].getStr().contains("Warsaw")


### PR DESCRIPTION
Hey, I wanted to use different 'provider' with your library and thought I would quickly develop a way to specify different `apiBase`. I also wanted to get rid of linting issues with README.md so made it more compliant. 

I also had test case working for me.